### PR TITLE
[fix]カレンダー表示するとmomentがwarn吐く #11

### DIFF
--- a/app/assets/javascripts/action_logs.coffee
+++ b/app/assets/javascripts/action_logs.coffee
@@ -9,6 +9,7 @@ $ ->
   }, (json) ->
     events = []
     for i,v of json
+      v.start = new Date(v.start);
       events[i] = v
     $('#action-log-cal').fullCalendar({
       titleFormat:


### PR DESCRIPTION
http://eiua-memo.tumblr.com/post/86394967273/tweet%E3%81%AE%E6%8A%95%E7%A8%BF%E6%99%82%E5%88%BB%E3%82%92momentjs%E3%81%A7%E5%BD%A2%E5%BC%8F%E5%A4%89%E6%8F%9B%E3%81%99%E3%82%8B%E3%81%A8%E3%81%8D%E3%81%AB%E8%AD%A6%E5%91%8A%E3%81%95%E3%82%8C%E3%82%8B

>JavaScriptのDateインスタントを生成して、それをmomentに渡すと直ります。